### PR TITLE
Add lighter tab border color to firefly-pro to match active tab color

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/ankitmlive/firefly-theme/issues",
         "email": "ankitmlive@gmail.com"
     },
-    "version": "3.0.1",
+    "version": "3.0.2",
     "engines": {
         "vscode": "^1.37.0"
     },

--- a/themes/firefly-pro.json
+++ b/themes/firefly-pro.json
@@ -83,8 +83,8 @@
         
 		"tab.activeBackground": "#343434",
 		"tab.activeForeground": "#a4bd00",
-		"tab.border": "#000000",
-		"tab.activeBorder": "#000000",
+		"tab.border": "#343434",
+		"tab.activeBorder": "#343434",
 		"tab.unfocusedActiveBorder": "#3d424d",
 		"tab.inactiveBackground": "#000000",
 		"tab.inactiveForeground": "#a0a8bd",


### PR DESCRIPTION
Changes the border and active border of tabs to a lighter color for firefly pro so that tabs can be more easily distinguished.

This fixes #7 

![image](https://user-images.githubusercontent.com/15203744/91049132-b9c49e80-e5ea-11ea-872e-049426d5eec9.png)
